### PR TITLE
Fixes

### DIFF
--- a/ctrl/controller.cpp
+++ b/ctrl/controller.cpp
@@ -21,6 +21,7 @@ Controller::Controller(Hw &hw, RpMsgTxInterface *rpmsg, ControllerStateDiagnosti
                     rpmsg(rpmsg)
 {
     pState = &state_normal_stopped;
+    pState->onEntry();
     rpmsg->registerReceiver(this);
 
 }
@@ -126,10 +127,10 @@ void Controller::handleGetAllInfo()
 void Controller::doIt()
 {
     // handling of emergency stop is independent of state
-    if(hw.lightBarrierEmergencyStop->isInterrupted())
+    /*if(hw.lightBarrierEmergencyStop->isInterrupted())
     {
         setState(&this->state_normal_stopped);
-    }
+    }*/
 
     // handle state specific behaviour
     pState->doIt();

--- a/hw/gpio.cpp
+++ b/hw/gpio.cpp
@@ -8,8 +8,8 @@ const uint32_t Gpio::VALVE3_MASK = 0x20;
 
 // inputs
 const uint32_t Gpio::PULSECOUNTER_MASK = 0x8000;
-const uint32_t Gpio::LIGHTBARRIER1_MASK = 0x10000;
-const uint32_t Gpio::LIGHTBARRIER2_MASK = 0x4000;
+const uint32_t Gpio::LIGHTBARRIER1_MASK = 0x4000;
+const uint32_t Gpio::LIGHTBARRIER2_MASK = 0x10000;
 const uint32_t Gpio::LIGHTBARRIERS3_TO_5_MASK = 0x4;
 
 Gpio::Gpio(uint32_t mask) : mask(mask)

--- a/hw/gpio.cpp
+++ b/hw/gpio.cpp
@@ -8,8 +8,8 @@ const uint32_t Gpio::VALVE3_MASK = 0x20;
 
 // inputs
 const uint32_t Gpio::PULSECOUNTER_MASK = 0x8000;
-const uint32_t Gpio::LIGHTBARRIER1_MASK = 0x4000;
-const uint32_t Gpio::LIGHTBARRIER2_MASK = 0x10000;
+const uint32_t Gpio::LIGHTBARRIER1_MASK = 0x10000;
+const uint32_t Gpio::LIGHTBARRIER2_MASK = 0x4000;
 const uint32_t Gpio::LIGHTBARRIERS3_TO_5_MASK = 0x4;
 
 Gpio::Gpio(uint32_t mask) : mask(mask)


### PR DESCRIPTION
In this pull request two problems have been resolved.

- After startup of the board (when the pru code is loaded), the conveyor is stopped.
- The code for hardware emergency stop has been commented out. As the lightbarriers 3-5 were attached to the emergency stop pin, this led to emergency stops, when all trays were filled.

Additionally two commits are included for swapped hardware pins of lb1 & lb2. This is needed as long as the potential crosstalk problem between lb1 and pulse counter is not resolved (use tag lightbarrier_1-2_swapped).